### PR TITLE
fix build by using sources and linking with libmysqlservices.a

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -156,33 +156,7 @@ else
 	if test "$mysql_headers_found" = "1"; then
 		AC_MSG_RESULT([found])
 	else
-		AC_MSG_RESULT([not found])
-	fi
-
-	# now check installed headers
-	if test "$mysql_headers_found" != "1"; then
-		AC_MSG_CHECKING([mysql installed headers in $with_mysql/include/mysql])
-		mysql_headers_found=0
-		HEADERS="private/handler.h private/table.h"
-
-		for file in $HEADERS; do
-			if test -r "$with_mysql/include/mysql/$file"; then
-				mysql_headers_found=1
-				mysql_headers_type="installed"
-			fi
-		done
-
-		if test "$mysql_headers_found" = "1"; then
-			AC_MSG_RESULT([found])
-		else
-			AC_MSG_RESULT([not found])
-		fi
-	fi
-
-	if test "$mysql_headers_found" != "1"; then
-		AC_MSG_ERROR([couldn't find either configured sources or installed headers])
-	else
-		AC_MSG_NOTICE([using $with_mysql ($mysql_headers_type)])
+		AC_MSG_ERROR([not found])
 	fi
 
 	# now check for version
@@ -191,9 +165,6 @@ else
 			MYSQL_INC="-DPINBA_USE_MYSQL_SOURCE -I$with_mysql -I$with_mysql/sql -I$with_mysql/regex -I$with_mysql/include"
 			# these are for mysql 5.7
 			MYSQL_INC="$MYSQL_INC -I$with_mysql/libbinlogevents/export -I$with_mysql/libbinlogevents/include"
-			;;
-		"installed")
-			MYSQL_INC="-I$with_mysql/include -I$with_mysql/include/mysql -I$with_mysql/include/mysql/private"
 			;;
 		*)
 			;;
@@ -204,6 +175,8 @@ else
 
 	CFLAGS="$MYSQL_INC"
 	CXXFLAGS="$MYSQL_INC"
+
+	MYSQL_SERVICES_LIB="$with_mysql/libservices/libmysqlservices.a"
 
 	AC_MSG_CHECKING([for MySQL version >= 5.1])
 	AC_TRY_RUN([
@@ -321,6 +294,7 @@ AC_SUBST(DEPS_CFLAGS)
 AC_SUBST(DEPS_LIBS)
 
 AC_SUBST(MYSQL_ENGINE_CFLAGS)
+AC_SUBST(MYSQL_SERVICES_LIB)
 AC_SUBST(INSTALL_STRIP_FLAG)
 
 AC_SUBST(EXPERIMENT_DIR)

--- a/docker/build-from-source.sh
+++ b/docker/build-from-source.sh
@@ -14,7 +14,7 @@ PACKAGES="hostname mariadb-server"
 # mkdir -p /_src && cd /_src
 
 # # pull sources
-# git clone https://github.com/anton-povarov/pinba2
+# git clone https://github.com/marko/pinba2
 # git clone https://github.com/anton-povarov/meow
 # git clone https://github.com/nanomsg/nanomsg
 
@@ -36,7 +36,7 @@ make install
 cd /_src/pinba2
 ./buildconf.sh
 ./configure --prefix=/_install/pinba2 \
-	--with-mysql=/usr \
+	--with-mysql=/home/builder/rpm/mariadb-10.1.26 \
 	--with-boost=/usr \
 	--with-meow=/_src/meow \
 	--with-nanomsg=/_install/nanomsg
@@ -47,5 +47,5 @@ make -j4
 cp /_src/pinba2/mysql_engine/.libs/libpinba_engine2.so `mysql_config --plugindir`
 
 # clean everything
-rm -rf /_src
-rm -rf /_install
+#rm -rf /_src
+#rm -rf /_install

--- a/docker/fedora-25/Dockerfile
+++ b/docker/fedora-25/Dockerfile
@@ -3,17 +3,48 @@ MAINTAINER  Anton Povarov "anton.povarov@gmail.com"
 
 RUN         dnf install -y git-core gcc gcc-c++ boost-devel cmake autoconf automake libtool mariadb-devel
 RUN         dnf install -y file hostname mariadb-server
+RUN			dnf install -y dnf-plugins-core rpm-build
+RUN			dnf builddep -y mariadb
+
+RUN 		useradd builder -u 1000 -m -G users,wheel && \
+    		echo "builder ALL=(ALL:ALL) NOPASSWD:ALL" >> /etc/sudoers && \
+    		echo "# macros"                      >  /home/builder/.rpmmacros && \
+    		echo "%_topdir    /home/builder/rpm" >> /home/builder/.rpmmacros && \
+    		echo "%_sourcedir %{_topdir}"        >> /home/builder/.rpmmacros && \
+    		echo "%_builddir  %{_topdir}"        >> /home/builder/.rpmmacros && \
+    		echo "%_specdir   %{_topdir}"        >> /home/builder/.rpmmacros && \
+    		echo "%_rpmdir    %{_topdir}"        >> /home/builder/.rpmmacros && \
+    		echo "%_srcrpmdir %{_topdir}"        >> /home/builder/.rpmmacros && \
+    		mkdir /home/builder/rpm && \
+    		chown -R builder /home/builder
+
+USER		builder
+WORKDIR		/home/builder
+
+RUN			dnf download --source mariadb
+RUN			rpm -i mariadb*.rpm
+
+WORKDIR		/home/builder/rpm
+RUN			rpmbuild --nocheck -bi mariadb.spec
+
+# RUN			echo 'test5' > test && rm test
+
+USER 		root
+WORKDIR		/root
 
 RUN         mkdir -p /_src && cd /_src && \
-			git clone https://github.com/anton-povarov/pinba2 && \
+			# git clone --branch=fix_lib https://github.com/mkevac/pinba2 && \
+			git clone https://github.com/badoo/pinba2 && \
 			git clone https://github.com/anton-povarov/meow && \
 			git clone https://github.com/nanomsg/nanomsg ;
 
 RUN         /_src/pinba2/docker/build-from-source.sh
 
 RUN         dnf remove -y git-core gcc gcc-c++ boost-devel cmake autoconf automake libtool mariadb-devel && \
+			dnf remove -y dnf-plugins-core rpm-build && \
 			dnf autoremove -y && \
-			dnf clean all
+			dnf clean all && \
+			rm -rf /home/builder/rpm/*
 
 COPY        docker-entrypoint.sh /usr/local/bin/
 RUN         ln -snf /usr/local/bin/docker-entrypoint.sh /

--- a/mysql_engine/Makefile.am
+++ b/mysql_engine/Makefile.am
@@ -34,5 +34,6 @@ libpinba_engine2_la_LDFLAGS = \
 
 libpinba_engine2_la_LIBADD = \
 	../src/libpinba2.a \
+	$(MYSQL_SERVICES_LIB) \
 	$(DEPS_LIBS) \
 	#


### PR DESCRIPTION
Fixes issue #2 

I've removed ability to build with just installed headers.
I am now using mariadb built from sources (*.src.rpm) in pinba build.
I am now building pinba with libmysqlservices.a needed for some symbols.