### PR TITLE
Fix incorrect internal threads shutdown on exception during startup 

### DIFF
--- a/src/collector.cpp
+++ b/src/collector.cpp
@@ -191,6 +191,11 @@ namespace { namespace aux {
 		void try_resolve_listen_addr_port()
 		{
 			os_addrinfo_list_ptr ai_list = os_unix::getaddrinfo_ex(conf_->address.c_str(), conf_->port.c_str(), AF_INET, SOCK_DGRAM, 0);
+			MEOW_UNIX_ADDRINFO_LIST_FOR_EACH(curr_addr, ai_list)
+			{
+				LOG_INFO(globals_->logger(), "udp_reader; resolved {0}:{1} -> {2}", conf_->address, conf_->port, curr_addr->ai_addr);
+			}
+
 			os_addrinfo_t *ai = ai_list.get(); // take 1st item for now
 
 			// commit if everything is ok

--- a/src/collector.cpp
+++ b/src/collector.cpp
@@ -200,8 +200,6 @@ namespace { namespace aux {
 
 		fd_handle_t try_bind_to_addr(os_addrinfo_t *ai)
 		{
-			throw std::runtime_error("emulate!");
-
 			fd_handle_t fd { os_unix::socket_ex(ai->ai_family, ai->ai_socktype, ai->ai_protocol) };
 			os_unix::setsockopt_ex(*fd, SOL_SOCKET, SO_REUSEADDR, 1);
 			os_unix::setsockopt_ex(*fd, SOL_SOCKET, SO_REUSEPORT, 1);

--- a/src/collector.cpp
+++ b/src/collector.cpp
@@ -129,6 +129,11 @@ namespace { namespace aux {
 			this->try_resolve_listen_addr_port();
 		}
 
+		~collector_impl_t()
+		{
+			this->shutdown();
+		}
+
 		virtual void startup() override
 		{
 			if (!threads_.empty())
@@ -165,6 +170,9 @@ namespace { namespace aux {
 
 		virtual void shutdown() override
 		{
+			if (threads_.empty())
+				return;
+
 			{
 				std::unique_lock<std::mutex> lk_(shutdown_mtx_);
 				shutdown_cli_sock_.send(1); // there is no need to send multiple times, threads exit on poll signal
@@ -174,6 +182,8 @@ namespace { namespace aux {
 			{
 				threads_[i].join();
 			}
+
+			threads_.clear();
 		}
 
 	private:
@@ -190,6 +200,8 @@ namespace { namespace aux {
 
 		fd_handle_t try_bind_to_addr(os_addrinfo_t *ai)
 		{
+			throw std::runtime_error("emulate!");
+
 			fd_handle_t fd { os_unix::socket_ex(ai->ai_family, ai->ai_socktype, ai->ai_protocol) };
 			os_unix::setsockopt_ex(*fd, SOL_SOCKET, SO_REUSEADDR, 1);
 			os_unix::setsockopt_ex(*fd, SOL_SOCKET, SO_REUSEPORT, 1);

--- a/src/coordinator.cpp
+++ b/src/coordinator.cpp
@@ -309,6 +309,11 @@ namespace { namespace aux {
 				.connect(conf_->nn_control);
 		}
 
+		~relay_worker_t()
+		{
+			this->shutdown();
+		}
+
 		void startup()
 		{
 			in_sock_.connect(conf_->nn_input);
@@ -322,6 +327,9 @@ namespace { namespace aux {
 
 		void shutdown()
 		{
+			if (!thread_.joinable()) // has actually started and not shut down yet
+				return;
+
 			// tell relay to stop operation
 			auto const err = this->execute_in_thread([this]()
 			{
@@ -460,7 +468,6 @@ namespace { namespace aux {
 		std::mutex          control_mtx_;
 
 		std::thread         thread_;
-
 	};
 
 ////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/globals.cpp
+++ b/src/globals.cpp
@@ -150,9 +150,9 @@ namespace { namespace aux {
 
 		virtual void shutdown() override
 		{
-			collector_->shutdown();
-			repacker_->shutdown();
-			coordinator_->shutdown();
+			collector_.reset();
+			repacker_.reset();
+			coordinator_.reset();
 		}
 
 		virtual pinba_globals_t* globals() const override

--- a/src/repacker.cpp
+++ b/src/repacker.cpp
@@ -244,6 +244,11 @@ namespace { namespace aux {
 		{
 		}
 
+		~repacker_impl_t()
+		{
+			this->shutdown();
+		}
+
 		virtual void startup() override
 		{
 			out_sock_
@@ -288,6 +293,9 @@ namespace { namespace aux {
 
 		virtual void shutdown() override
 		{
+			if (threads_.empty())
+				return;
+
 			{
 				std::unique_lock<std::mutex> lk_(shutdown_mtx_);
 				shutdown_cli_sock_.send(1); // there is no need to send multiple times, threads exit on poll signal
@@ -297,6 +305,8 @@ namespace { namespace aux {
 			{
 				threads_[i].join();
 			}
+
+			threads_.clear();
 		}
 
 	private:


### PR DESCRIPTION
This fixes std::terminate when we can't bind to port for example.
Subject to further refinement ~~(and need to remove hardcoded test exception)~~.