### PR TITLE
Implement ipv6 and multiple dgram sockets support

### DIFF
--- a/mysql_engine/plugin.cpp
+++ b/mysql_engine/plugin.cpp
@@ -351,7 +351,7 @@ static MYSQL_SYSVAR_INT(port,
 static MYSQL_SYSVAR_STR(address,
 	pinba_variables()->address,
 	PLUGIN_VAR_RQCMDARG | PLUGIN_VAR_READONLY,
-	"IP address to listen at (use 0.0.0.0 here if you want to listen on all IPs), must not be empty",
+	"IP address to listen at (use * for all IPs, 0.0.0.0 for all v4 IPs, :: for all v6 IPs), must not be empty",
 	[](MYSQL_THD thd, struct st_mysql_sys_var *var, void *tmp, struct st_mysql_value *value)
 	{
 		// disallow empty address
@@ -363,7 +363,7 @@ static MYSQL_SYSVAR_STR(address,
 		return 0;
 	},
 	NULL,
-	"0.0.0.0");
+	"*");
 
 static MYSQL_SYSVAR_STR(log_level,
 	pinba_variables()->log_level,

--- a/src/collector.cpp
+++ b/src/collector.cpp
@@ -220,7 +220,7 @@ namespace { namespace aux {
 			os_unix::setsockopt_ex(*fd, SOL_SOCKET, SO_REUSEADDR, 1);
 			os_unix::setsockopt_ex(*fd, SOL_SOCKET, SO_REUSEPORT, 1);
 			if (ai->ai_family == AF_INET6)
-				os_unix::setsockopt_ex(*fd, IPPROTO_IPV6, IPV6_V6ONLY, int(~0));
+				os_unix::setsockopt_ex(*fd, IPPROTO_IPV6, IPV6_V6ONLY, 1);
 			os_unix::bind_ex(*fd, ai->ai_addr, ai->ai_addrlen);
 
 			return fd;


### PR DESCRIPTION
On Badoo-internal request (CT-3749): support listening on ipv6 addresses (and on both ipv4 and ipv6 for 'all interfaces setting').

This has non-trivial interactions with 'wait 1 millisecond between mass udp reads' that we use to save on system calls.
Should not be a problem if only one socket (address) is really heavily loaded. But might incur imbalance if multiple are loaded, so care must be taken.

Still work in progress.
Requires latest meow.git