### PR TITLE
Switch to std cpp 14

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,19 +5,22 @@ config.sub
 config.nice
 config.status
 configure
+compile
 depcomp
+.dirstamp
 install-sh
 libtool
 ltmain.sh
 aclocal.m4
 stamp-h1
-m4
+m4/
 missing
-perf.data
+perf.data*
 .deps
 .libs
 _configs.sed
 auto_config.h
+pinba2
 pinba_config.h
 pinba_config.h~
 pinba_config.h.in
@@ -29,4 +32,6 @@ pinba_config.h.in~
 *.lo
 *.sublime-*
 .idea
+Makefile
+Makefile.in
 

--- a/configure.ac
+++ b/configure.ac
@@ -40,7 +40,7 @@ common_flags="$common_flags -D_GNU_SOURCE -D_POSIX_SOURCE"
 common_flags="$common_flags -maes -msse4 -msse4.2"
 
 AX_CFLAGS="-std=gnu11 $common_flags"
-AX_CXXFLAGS="-std=gnu++11 -fno-rtti $common_flags"
+AX_CXXFLAGS="-std=c++14 -fno-rtti $common_flags"
 AX_LDFLAGS="-flto -lrt -ldl"
 
 dnl nonportable pthread expensions


### PR DESCRIPTION
Initial c++14 move, not all cases covered, but switched to `-std=c++14` compilation flag.
fixes #15 
