### PR TITLE
Add per select dictionary read cache

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -28,7 +28,6 @@
 - tools
 	- [x] rtag_* reports support in scripts/convert_mysqldump.php
 	- [ ] hv_* reports support in scripts/convert_mysqldump.php
-- [ ] pthread_setname_np portable detection at runtime {?}
 - [ ] {maybe} raw data support
 - [ ] {maybe, not strictly needed} calculate real time window for report snapshots (i.e. skip timeslices that have had no data)
 	- this is debatable, but useful for correct <something>/sec calculations
@@ -41,13 +40,15 @@
 	- [ ] split permanent dictionary into it's own api, use for all tag names (never refcount them)
 	- [ ] maybe rework dictionaries to be report-based (this virtually eliminates the need for repacker, but will prob require report thread-splitting)
 	- [ ] hash strings only once, hack hash table impls to accept hashes instead of strings (impossible with unordered_map?)
+	- [x] {medium} per snapshot merger dictionary caches
+- [ ] {easy} check dense_hash_map impls
+	- [ ] https://github.com/tbricks/sparsehash-c11/commits/development (c++11 move + performance)
+	- [ ] check other hashes in general: https://tessil.github.io/2016/08/29/benchmark-hopscotch-map.html#which-hash-map-should-i-choose
 - [ ] {medium} thread cpu + numa affinity
 	- [ ] coordinator (or packet relay for that matter) affinity + priority
 	- [ ] repacker affinity + config support
 	- [ ] udp collector affinity + config support
 	- [ ] doc, how to assign interrupts to cores + numa nodes (links at least)
-- [ ] {easy} check dense_hash_map impls
-	- [ ] https://github.com/tbricks/sparsehash-c11/commits/development (c++11 move + performance)
 - [ ] {?} increase udp kernel memory (or at least check for it) on startup
 	- kernel udp memory is usually tuned very low
 	- so, it's beneficial to increase it to be able to handle high packet+data rates
@@ -56,13 +57,12 @@
 	- hard to change all clients
 	- not really worth it, since pb unpack doesn't seem to take that much cpu
 - [ ] {hard} maybe replace nanomsg with something doing less locking / syscalls (thorough meamurements first!)
-- [ ] {medium, worth it?} per snapshot merger dictionary caches
 
 # Internals
 - [x] split pinba_globals_t into 'informational' and 'runtime engine' parts (to simplify testing/experiments)
 	- informational: stats, ticker, dictionary, stuff that is just 'cogs'
 	- runtime: udp readers, coorinator, the features meat
-- [ ] split coordinator into 'relay thread' and 'management thread' (maybe even have management be non-threaded?)
+- [x] split coordinator into 'relay thread' and 'management thread' (management is non-threaded, but needs locking, as it can be used from multiple threads)
 - [ ] refactor switches by view type in handler.cpp / view_conf.cpp
 
 # Done
@@ -123,3 +123,4 @@
 	- [x] {actually done} rewritten hdr histogram to suit our needs, now using it at 'current tick' aggregation stage
 	- [x] {won't do} hack to allow for dynamic resize (currently too expensive to use, as they preallocate on creation)
 	- [x] also need to figure out what to do with negative/positive inf in our histograms, and significant digits setting
+- [x] pthread_setname_np portable detection at runtime {?}

--- a/include/pinba/dictionary.h
+++ b/include/pinba/dictionary.h
@@ -147,13 +147,6 @@ struct dictionary_t : private boost::noncopyable
 		{
 		}
 
-		word_t(word_t&& other)
-			: refcount(other.refcount)
-			, id(other.id)
-			, str(std::move(other.str))
-		{
-		}
-
 		void set(uint32_t i, str_ref s)
 		{
 			id = i;
@@ -383,18 +376,12 @@ private:
 	// get or create a word, REFCOUNT IS NOT MODIFIED, i.e. even if just created -> refcount == 0
 	word_t* get_or_add___wrlocked(shard_t *shard, str_ref const word)
 	{
-		// just insert, word might've appeared while upgrading the lock
-		// if that's the case - good, we'd have some non-null pointer in value (and just return)
-		word_t *& hashed_word_ptr = shard->hash[word];
-		if (hashed_word_ptr != nullptr)
-			return hashed_word_ptr;
+		// re-check word existence, might've appeated while upgrading the lock
+		auto it = shard->hash.find(word);
+		if (shard->hash.end() != it)
+			return it->second;
 
-		// auto it = shard->hash.find(word);
-		// if (shard->hash.end() != it)
-		// 	return it->second;
-
-		// word wasn't there, so create new one and set
-		// going to be really slow, mon
+		// need to insert, going to be really slow, mon
 
 		shard->mem_used_by_word_strings += word.size();
 
@@ -427,11 +414,7 @@ private:
 			}
 		}();
 
-		// commit now
-		hashed_word_ptr = w;
-
-		// TODO: use c++11 dense hash + emplace here (or maybe just try insert at the start of this func)
-		// shard->hash.insert({ str_ref { w->str }, w });
+		shard->hash.insert({ str_ref { w->str }, w });
 
 		return w;
 	}

--- a/include/pinba/dictionary.h
+++ b/include/pinba/dictionary.h
@@ -457,6 +457,69 @@ private:
 // 	}
 // };
 
+// single threaded cache for dictionary_t
+// transforms word_id -> word only
+// intended to save on global dictionary locking, by caching stuff locally
+// should be very efficient for wide reports with many repeating values
+// XXX(antoxa): maybe move this out of global header, somewhere close to report_snapshot impls
+struct snapshot_dictionary_t : private boost::noncopyable
+{
+	struct word_id_hasher_t
+	{
+		inline uint64_t operator()(uint32_t const key) const
+		{
+			return t1ha0(&key, sizeof(key), key);
+		}
+	};
+
+	using hashtable_t = google::dense_hash_map<uint32_t, str_ref, word_id_hasher_t>;
+
+	struct id_to_word_hash_t : public hashtable_t
+	{
+		id_to_word_hash_t()
+			// pre-allocate to avoid some resizes,
+			// this allocates (24 bytes per node) * 2^17 = 1.5Mb
+			// -1 is important, due to how dense_hash calculates real bucket_count (< vs <=)
+			: hashtable_t(32 * 1024 - 1)
+		{
+			this->set_empty_key(PINBA_INTERNAL___UINT32_MAX);
+		}
+	};
+
+private:
+
+	mutable id_to_word_hash_t  words_ht;
+	dictionary_t const         *d;
+
+public:
+
+	explicit snapshot_dictionary_t(dictionary_t const *dict)
+		: d(dict)
+	{
+		assert(d != nullptr);
+	}
+
+	// XXX(antoxa): it's important to understand word lifetimes using this function
+	// for report snapshots (where this is supposed to be used) - we rely on repacker_state to keep words alive
+	str_ref get_word(uint32_t word_id) const
+	{
+		if (word_id == 0)
+			return {};
+
+		// fastpath: local lookup
+		str_ref& value_ref = this->words_ht[word_id];
+		if (!value_ref.empty()) // found
+			return value_ref;
+
+		// slowpath: remote lookup with read lock
+		str_ref const remote_value = d->get_word(word_id);
+		assert(!remote_value.empty() && "got empty word for non-zero word_id");
+
+		value_ref = remote_value;
+		return value_ref;
+	}
+};
+
 ////////////////////////////////////////////////////////////////////////////////////////////////
 // single threaded cache for dictionary_t to be used by repacker
 // get_or_add only, i.e. str_ref -> uint32_t

--- a/include/pinba/report.h
+++ b/include/pinba/report.h
@@ -138,11 +138,10 @@ struct report_snapshot_t
 	// histograms configuration
 	virtual histogram_conf_t const* histogram_conf() const = 0;
 
-	// get dictionary used to translate ids to names, read only
-	virtual dictionary_t const* dictionary() const = 0;
-
-	// get thread-local this snapshot only dictionary
-	// virtual snapshot_dictionary_t const* snapshot_dictionary() const = 0;
+	// get global dictionary used to translate ids to names, read only
+	virtual dictionary_t const*          dictionary() const = 0;
+	// get local dictionary cache, that can do cached word_id -> word translation
+	virtual snapshot_dictionary_t const* snapshot_dictionary() const = 0;
 
 	// prepare snapshot for use
 	// MUST be called before any of the functions below

--- a/include/pinba/report_util.h
+++ b/include/pinba/report_util.h
@@ -259,16 +259,18 @@ struct report_snapshot__impl_t
 
 public: // intentional, internal use only
 
-	hashtable_t  data_;      // real data we iterate over
-	src_ticks_t  ticks_;     // ticks we merge our data from (in other thread potentially)
-	totals_t     totals_;    // totals storage
-	bool         prepared_;  // has data been prepared?
+	hashtable_t            data_;      // real data we iterate over
+	src_ticks_t            ticks_;     // ticks we merge our data from (in other thread potentially)
+	snapshot_dictionary_t  snap_d_;    // local snapshot dictionary word_id -> word cache
+	totals_t               totals_;    // totals storage
+	bool                   prepared_;  // has data been prepared?
 
 public:
 
 	report_snapshot__impl_t(report_snapshot_ctx_t ctx, src_ticks_t const& ticks)
 		: report_snapshot_ctx_t(ctx)
 		, ticks_(ticks)
+		, snap_d_(ctx.globals->dictionary())
 		, prepared_(false)
 	{
 	}
@@ -288,6 +290,11 @@ private:
 	virtual dictionary_t const* dictionary() const override
 	{
 		return globals->dictionary();
+	}
+
+	virtual snapshot_dictionary_t const* snapshot_dictionary() const
+	{
+		return &snap_d_;
 	}
 
 	virtual void prepare(merge_flags_t flags) override
@@ -401,8 +408,7 @@ private:
 		for (uint32_t i = 0; i < k.size(); ++i)
 		{
 			// str_ref const word = dictionary()->get_word(k[i]);
-			// str_ref const word = snapshot_d.get_word(k[i]);
-			str_ref const word = dictionary()->get_word(k[i]); // FIXME
+			str_ref const word = snapshot_dictionary()->get_word(k[i]);
 			result.push_back(word);
 		}
 		return result;


### PR DESCRIPTION
Should achieve two things
- speed up selects by avoiding global (read-locked) dictionary lookup. Useful for reports containing multiple repeating words (most of them).
- reduce rw lock contention on global dictionary. Selects to a ton of lookups, and our rwlock doesn't have writer priority (for now) - which might lead to writer (repacker threads) starvation.

this is WIP