### PR TITLE
adjust entrypoint script in a way, what it will not fail while starting existing, but stopped container

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -40,6 +40,7 @@ if [ $1 = "mysqld" ]; then
 	mysql --protocol=socket -uroot <<-EOSQL
 			SET @@SESSION.SQL_LOG_BIN=0;
 			DELETE from mysql.user;
+			FLUSH PRIVILEGES;
 			CREATE USER 'root'@'%' IDENTIFIED BY '${MYSQL_ROOT_PASSWORD}' ;
 			GRANT ALL ON *.* TO 'root'@'%' WITH GRANT OPTION ;
 			FLUSH PRIVILEGES ;
@@ -47,9 +48,10 @@ if [ $1 = "mysqld" ]; then
 
 	# install plugin and create default db
 	# TODO: Use --init-file https://mariadb.com/kb/en/library/server-system-variables/#init_file
+	mysql --protocol=socket -uroot -e 'SHOW PLUGINS' | grep pinba \
+		|| mysql --protocol=socket -uroot -e "INSTALL PLUGIN pinba SONAME 'libpinba_engine2.so'"
 	mysql --protocol=socket -uroot <<-EOSQL
-		INSTALL PLUGIN pinba SONAME 'libpinba_engine2.so';
-		CREATE DATABASE pinba;
+		CREATE DATABASE IF NOT EXISTS pinba;
 	EOSQL
 
 	# TODO: create default tables from scripts/default_tables.sql


### PR DESCRIPTION
Hi @tony2001 and @anton-povarov.

While adding pinba to development environment made by docker-compose, I noticed that pinba start successfully only for the first time, and when container was stopped and then started again - it fails. 

I realised, that installation commands are written to be executed only once.

Here is my proposal how to fix this.