### PR TITLE
add protobuffers version to proto file

### DIFF
--- a/proto/pinba.proto
+++ b/proto/pinba.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 package Pinba;
 option optimize_for = LITE_RUNTIME;
 


### PR DESCRIPTION
I think it makes sense to add the protobuffers version tag to the .proto spec as it can help end users who might want to use it to decode raw protobuf messages when debugging their apps which need to talk to the pinba2 engine - at least it would have saved me the time I wasted digging into all the differences between protobuffers versions ;-)

The tag added makes it mandatory to use, afaict, protoc compiler 3.0 or later to parse the file. That was released in 2016 and is the default in all currently supported lts releases of Debian and Ubuntu, so there is little chance of users still relying on older versions.
